### PR TITLE
[Discover] App menu touchups

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/index.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/index.ts
@@ -11,3 +11,4 @@ export { BrandedLoadingIndicator } from './branded_loading_indicator';
 export { NoDataPage } from './no_data_page';
 export { InitializationError } from './initialization_error';
 export { SingleTabView, type SingleTabViewProps } from './single_tab_view';
+export { SingleTabViewWithAppMenu } from './single_tab_view_with_app_menu';

--- a/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/single_tab_view/single_tab_view.tsx
@@ -152,7 +152,7 @@ export const SingleTabView = ({
 
   if (currentTabInitializationState.initializationStatus === TabInitializationStatus.NoData) {
     return (
-      <HideTabsBar>
+      <HideTabsBar customizationContext={customizationContext}>
         <NoDataPage
           {...appInitializationState}
           onDataViewCreated={async (dataViewUnknown) => {

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/hide_tabs_bar.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/hide_tabs_bar.tsx
@@ -8,12 +8,21 @@
  */
 
 import type { FC, ReactNode } from 'react';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { AppMenu } from '@kbn/core-chrome-app-menu';
 import { internalStateActions, useInternalStateDispatch } from '../../state_management/redux';
 import { TabsBarVisibility } from '../../state_management/redux/types';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import { useTopNavMenuItems } from '../top_nav/use_top_nav_menu_items';
+import type { DiscoverCustomizationContext } from '../../../../customizations';
 
-export const HideTabsBar: FC<{ children: ReactNode }> = ({ children }) => {
+export const HideTabsBar: FC<{
+  customizationContext: DiscoverCustomizationContext;
+  children: ReactNode;
+}> = ({ customizationContext, children }) => {
   const dispatch = useInternalStateDispatch();
+  const { chrome } = useDiscoverServices();
+  const topNavMenuItems = useTopNavMenuItems();
 
   useEffect(() => {
     dispatch(internalStateActions.setTabsBarVisibility(TabsBarVisibility.hidden));
@@ -22,5 +31,17 @@ export const HideTabsBar: FC<{ children: ReactNode }> = ({ children }) => {
     };
   }, [dispatch]);
 
-  return children;
+  return (
+    <>
+      {
+        /**
+         * The tabs bar renders the app menu, but it still needs to be shown when tabs are hidden
+         */
+        customizationContext.displayMode === 'standalone' && topNavMenuItems && (
+          <AppMenu config={topNavMenuItems} setAppMenu={chrome.setAppMenu} />
+        )
+      }
+      {children}
+    </>
+  );
 };

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_app_menu_data.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_app_menu_data.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { EuiResizeObserverProps } from '@elastic/eui';
-import type { UnifiedTabsProps, TabMenuItem } from '@kbn/unified-tabs';
+import type { UnifiedTabsProps } from '@kbn/unified-tabs';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { i18n } from '@kbn/i18n';
 import { METRIC_TYPE } from '@kbn/analytics';
@@ -20,11 +20,12 @@ import {
   useInternalStateDispatch,
   useInternalStateSelector,
   useCurrentTabAction,
+  selectAllTabs,
 } from '../../state_management/redux';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
-import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';
 import { useTopNavMenuItems } from '../top_nav/use_top_nav_menu_items';
+import { isEsqlSource } from '../../../../../common/data_sources';
 
 const APP_MENU_COLLAPSE_THRESHOLD = 800;
 
@@ -42,61 +43,76 @@ interface UseAppMenuDataResult {
 export const useAppMenuData = ({ currentDataView }: UseAppMenuDataParams): UseAppMenuDataResult => {
   const services = useDiscoverServices();
   const dispatch = useInternalStateDispatch();
-  const isEsqlMode = useIsEsqlMode();
+  const allTabs = useInternalStateSelector(selectAllTabs);
   const currentTabId = useInternalStateSelector((state) => state.tabs.unsafeCurrentId);
   const unsavedTabIds = useInternalStateSelector((state) => state.tabs.unsavedIds);
+  const persistedDiscoverSession = useInternalStateSelector(
+    (state) => state.persistedDiscoverSession
+  );
   const [shouldCollapseAppMenu, setShouldCollapseAppMenu] = useState(false);
 
   const transitionFromESQLToDataView = useCurrentTabAction(
     internalStateActions.transitionFromESQLToDataView
   );
 
-  // Determine if we should show the ES|QL to Data View transition modal
-  const persistedDiscoverSession = useInternalStateSelector(
-    (state) => state.persistedDiscoverSession
-  );
-  const shouldShowESQLToDataViewTransitionModal =
-    !persistedDiscoverSession || unsavedTabIds.includes(currentTabId);
-
   const onResize: EuiResizeObserverProps['onResize'] = useCallback((dimensions) => {
     if (!dimensions) return;
     setShouldCollapseAppMenu(dimensions.width < APP_MENU_COLLAPSE_THRESHOLD);
   }, []);
 
-  // Provide "Switch to Classic" menu item for tabs when in ES|QL mode
-  const getAdditionalTabMenuItems: UnifiedTabsProps['getAdditionalTabMenuItems'] = useMemo(() => {
-    if (!isEsqlMode || !services.uiSettings.get(ENABLE_ESQL)) {
-      return undefined;
-    }
+  // Provide "Switch to Classic" menu item for the selected tab when in ES|QL mode
+  const getAdditionalTabMenuItems = useCallback<
+    NonNullable<UnifiedTabsProps['getAdditionalTabMenuItems']>
+  >(
+    (item) => {
+      if (!services.uiSettings.get(ENABLE_ESQL)) {
+        return [];
+      }
 
-    return (): TabMenuItem[] => [
-      {
-        'data-test-subj': 'unifiedTabs_tabMenuItem_switchToClassic',
-        name: 'switchToClassic',
-        label: i18n.translate('discover.localMenu.switchToClassicTitle', {
-          defaultMessage: 'Switch to classic',
-        }),
-        onClick: () => {
-          services.trackUiMetric?.(METRIC_TYPE.CLICK, `esql:back_to_classic_clicked`);
-          if (
-            shouldShowESQLToDataViewTransitionModal &&
-            !services.storage.get(ESQL_TRANSITION_MODAL_KEY)
-          ) {
-            dispatch(internalStateActions.setIsESQLToDataViewTransitionModalVisible(true));
-          } else {
-            dispatch(transitionFromESQLToDataView({ dataViewId: currentDataView?.id ?? '' }));
-          }
+      const tab = allTabs.find((t) => t.id === item.id);
+      const isCurrentTab = tab?.id === currentTabId;
+
+      if (!isCurrentTab || !isEsqlSource(tab.appState.dataSource)) {
+        return [];
+      }
+
+      return [
+        {
+          'data-test-subj': 'unifiedTabs_tabMenuItem_switchToClassic',
+          name: 'switchToClassic',
+          label: i18n.translate('discover.localMenu.switchToClassicTitle', {
+            defaultMessage: 'Switch to classic',
+          }),
+          onClick: () => {
+            services.trackUiMetric?.(METRIC_TYPE.CLICK, `esql:back_to_classic_clicked`);
+
+            // Determine if we should show the ES|QL to Data View transition modal
+            const shouldShowESQLToDataViewTransitionModal =
+              !persistedDiscoverSession || unsavedTabIds.includes(tab.id);
+
+            if (
+              shouldShowESQLToDataViewTransitionModal &&
+              !services.storage.get(ESQL_TRANSITION_MODAL_KEY)
+            ) {
+              dispatch(internalStateActions.setIsESQLToDataViewTransitionModalVisible(true));
+            } else {
+              dispatch(transitionFromESQLToDataView({ dataViewId: currentDataView?.id ?? '' }));
+            }
+          },
         },
-      },
-    ];
-  }, [
-    isEsqlMode,
-    services,
-    shouldShowESQLToDataViewTransitionModal,
-    dispatch,
-    transitionFromESQLToDataView,
-    currentDataView,
-  ]);
+      ];
+    },
+    [
+      allTabs,
+      currentDataView?.id,
+      currentTabId,
+      dispatch,
+      persistedDiscoverSession,
+      services,
+      transitionFromESQLToDataView,
+      unsavedTabIds,
+    ]
+  );
 
   const topNavMenuItems = useTopNavMenuItems();
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_app_menu_data.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/tabs_view/use_app_menu_data.ts
@@ -7,16 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { EuiResizeObserverProps } from '@elastic/eui';
 import type { UnifiedTabsProps, TabMenuItem } from '@kbn/unified-tabs';
-import useObservable from 'react-use/lib/useObservable';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { i18n } from '@kbn/i18n';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { ENABLE_ESQL } from '@kbn/esql-utils';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { discoverTopNavMenuContext } from '../top_nav/discover_topnav_menu';
 import {
   internalStateActions,
   useInternalStateDispatch,
@@ -26,6 +24,7 @@ import {
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';
+import { useTopNavMenuItems } from '../top_nav/use_top_nav_menu_items';
 
 const APP_MENU_COLLAPSE_THRESHOLD = 800;
 
@@ -99,8 +98,7 @@ export const useAppMenuData = ({ currentDataView }: UseAppMenuDataParams): UseAp
     currentDataView,
   ]);
 
-  const { topNavMenu$ } = useContext(discoverTopNavMenuContext);
-  const topNavMenuItems = useObservable(topNavMenu$, topNavMenu$.getValue());
+  const topNavMenuItems = useTopNavMenuItems();
 
   return {
     shouldCollapseAppMenu,

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.test.tsx
@@ -104,7 +104,7 @@ const getTestComponent = (props: DiscoverTopNavProps) =>
       stateContainer={props.stateContainer}
       runtimeState={{ currentDataView: dataViewMock, adHocDataViews: [] }}
     >
-      <DiscoverTopNavMenuProvider>
+      <DiscoverTopNavMenuProvider customizationContext={props.stateContainer.customizationContext}>
         <TopNavMenuCapture />
         <DiscoverTopNav {...props} />
       </DiscoverTopNavMenuProvider>

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -236,7 +236,7 @@ export const DiscoverTopNav = ({
     [dataView.id, dispatch, services, stateContainer, transitionFromESQLToDataView]
   );
 
-  const { topNavMenu } = useDiscoverTopNav({
+  const { topNavBadges, topNavMenu } = useDiscoverTopNav({
     stateContainer,
     persistedDiscoverSession,
   });
@@ -342,7 +342,7 @@ export const DiscoverTopNav = ({
 
   return (
     <span>
-      <DiscoverTopNavMenu topNavMenu={topNavMenu} />
+      <DiscoverTopNavMenu topNavBadges={topNavBadges} topNavMenu={topNavMenu} />
       <SearchBar
         useBackgroundSearchButton={
           stateContainer.customizationContext.displayMode !== 'embedded' &&

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_discover_topnav.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
 import { useIsWithinBreakpoints } from '@elastic/eui';
 import { useDiscoverCustomization } from '../../../../customizations';
@@ -45,15 +45,6 @@ export const useDiscoverTopNav = ({
       }),
     [stateContainer, services, isMobile]
   );
-
-  useEffect(() => {
-    if (stateContainer.customizationContext.displayMode === 'standalone') {
-      services.chrome.setBreadcrumbsBadges(topNavBadges);
-      return () => {
-        services.chrome.setBreadcrumbsBadges([]);
-      };
-    }
-  }, [topNavBadges, services.chrome, stateContainer.customizationContext.displayMode]);
 
   const dataView = useCurrentDataView();
   const adHocDataViews = useAdHocDataViews();

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -255,22 +255,6 @@ export const useTopNavLinks = ({
     if (services.capabilities.discover_v2.save && !defaultMenu?.saveItem?.disabled) {
       const isEmbeddedEditor = services.embeddableEditor.isEmbeddedEditor();
 
-      // In embedded editor mode, add "Cancel" button
-      if (isEmbeddedEditor) {
-        newAppMenuRegistry.registerItems([
-          {
-            id: 'cancel',
-            order: 100,
-            label: i18n.translate('discover.localMenu.cancelTitle', {
-              defaultMessage: 'Cancel',
-            }),
-            testId: 'discoverCancelButton',
-            run: services.embeddableEditor.transferBackToEditor,
-            iconType: 'editorUndo',
-          },
-        ]);
-      }
-
       newAppMenuRegistry.setPrimaryActionItem({
         id: 'save',
         label: isEmbeddedEditor
@@ -289,26 +273,36 @@ export const useTopNavLinks = ({
             onSaveCb: isEmbeddedEditor ? services.embeddableEditor.transferBackToEditor : undefined,
           });
         },
-        // Only show split button options when not in embedded editor mode
-        ...(isEmbeddedEditor
-          ? {}
-          : {
-              popoverWidth: 150,
-              popoverTestId: 'discoverSaveButtonPopover',
-              splitButtonProps: {
+        popoverWidth: 150,
+        popoverTestId: 'discoverSaveButtonPopover',
+        splitButtonProps: {
+          secondaryButtonIcon: 'arrowDown',
+          secondaryButtonAriaLabel: i18n.translate('discover.localMenu.saveOptionsAriaLabel', {
+            defaultMessage: 'Save options',
+          }),
+          // Show different split button options when in embedded editor mode
+          ...(isEmbeddedEditor
+            ? {
+                items: [
+                  {
+                    run: services.embeddableEditor.transferBackToEditor,
+                    id: 'cancel',
+                    order: 100,
+                    label: i18n.translate('discover.localMenu.cancelTitle', {
+                      defaultMessage: 'Cancel',
+                    }),
+                    iconType: 'editorUndo',
+                    testId: 'discoverCancelButton',
+                  },
+                ],
+              }
+            : {
                 showNotificationIndicator: hasUnsavedChanges,
                 notifcationIndicatorTooltipContent: hasUnsavedChanges
                   ? i18n.translate('discover.localMenu.unsavedChangesTooltip', {
                       defaultMessage: 'You have unsaved changes',
                     })
                   : undefined,
-                secondaryButtonIcon: 'arrowDown',
-                secondaryButtonAriaLabel: i18n.translate(
-                  'discover.localMenu.saveOptionsAriaLabel',
-                  {
-                    defaultMessage: 'Save options',
-                  }
-                ),
                 items: [
                   {
                     run: async () => {
@@ -348,8 +342,8 @@ export const useTopNavLinks = ({
                     disableButton: !hasUnsavedChanges,
                   },
                 ],
-              },
-            }),
+              }),
+        },
       });
     }
 

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -33,8 +33,9 @@ import {
   BrandedLoadingIndicator,
   NoDataPage,
   InitializationError,
+  SingleTabViewWithAppMenu,
+  SingleTabView,
 } from './components/single_tab_view';
-import { SingleTabViewWithAppMenu } from './components/single_tab_view/single_tab_view_with_app_menu';
 import { useAsyncFunction } from './hooks/use_async_function';
 import { TabsView } from './components/tabs_view';
 import { ChartPortalsRenderer } from './components/chart';
@@ -104,7 +105,9 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
   const history = useHistory();
   const dispatch = useInternalStateDispatch();
   const rootProfileState = useRootProfile();
-  const tabsEnabled = !services.embeddableEditor.isByValueEditor();
+  const tabsEnabled =
+    !services.embeddableEditor.isByValueEditor() &&
+    customizationContext.displayMode === 'standalone';
 
   const { initializeProfileDataViews } = useDefaultAdHocDataViews();
   const [mainRouteInitializationState, initializeMainRoute] = useAsyncFunction<InitializeMainRoute>(
@@ -264,11 +267,21 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
                     defaultMessage: 'Discover - Session not yet saved',
                   })}
             </h1>
-            {tabsEnabled && customizationContext.displayMode !== 'embedded' ? (
-              <TabsView {...props} />
-            ) : (
-              <SingleTabViewWithAppMenu {...props} />
-            )}
+            {
+              /**
+               * We need to account for three different display modes:
+               * - If tabs are enabled, show the tabs bar and the app menu.
+               * - If tabs are disabled and Discover is embedded, hide both the tabs bar and the app menu.
+               * - If tabs are disabled and Discover is standalone, hide the tabs bar but show the app menu.
+               */
+              tabsEnabled ? (
+                <TabsView {...props} />
+              ) : customizationContext.displayMode === 'embedded' ? (
+                <SingleTabView {...props} />
+              ) : (
+                <SingleTabViewWithAppMenu {...props} />
+              )
+            }
           </>
         </DiscoverTopNavMenuProvider>
       </ChartPortalsRenderer>

--- a/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/discover_main_route.tsx
@@ -253,7 +253,7 @@ const DiscoverMainRouteContent = (props: SingleTabViewProps) => {
   return (
     <rootProfileState.AppWrapper>
       <ChartPortalsRenderer runtimeStateManager={runtimeStateManager}>
-        <DiscoverTopNavMenuProvider>
+        <DiscoverTopNavMenuProvider customizationContext={customizationContext}>
           <>
             <h1 className="euiScreenReaderOnly" data-test-subj="discoverSavedSearchTitle">
               {persistedDiscoverSession?.title


### PR DESCRIPTION
## Summary

This PR includes a few touchups for the Discover app menu integration based on my findings while testing:
- Make sure the app menu renders correctly in all scenarios: https://github.com/kowalczyk-krzysztof/kibana/commit/dadbe1a35f1a574d6cd6751fdbf12b14c8c365d3. Not super happy with this approach, but that's for us to clean up later. It should now render correctly in all cases:
  - When tabs are enabled or disabled
  - In Security Timelines
  - In the Discover customization example app
  - In the Discover no data views screen
- Only show the switch to classic button in the currently selected tab's menu: https://github.com/kowalczyk-krzysztof/kibana/commit/bb75ed891f6dcdb795aae45a89aacc429e0273e2. The current implementation shows the button in all tab menus, but clicking it always applies to the current tab. Not the best UX, but the action currently only works for the selected tab, so it'll do for now and can be cleaned up later.
- Put the embeddable editor cancel button into the primary item split menu to better align with the new save UX: https://github.com/kowalczyk-krzysztof/kibana/commit/1dc3842cee106b75fdd0c751844c3030f741f85e.
- Revert some changes around `topNavBadges` since the current implementation causes the badges to flicker when opening new tabs in ES|QL mode: https://github.com/kowalczyk-krzysztof/kibana/commit/599e81f2a1f8a06bdc022f132beb77ea1cfc61e9.